### PR TITLE
Fix PHP error when scanning for single domain, but other strings found.

### DIFF
--- a/src/Utils/FunctionsScanner.php
+++ b/src/Utils/FunctionsScanner.php
@@ -70,7 +70,7 @@ abstract class FunctionsScanner
                 continue;
             }
 
-            if (!$isDefaultDomain && !$domainTranslations) {
+            if (!$domainTranslations) {
                 continue;
             }
 

--- a/tests/AssetsTest.php
+++ b/tests/AssetsTest.php
@@ -548,6 +548,15 @@ class AssetsTest extends AbstractTest
         }
     }
 
+    public function testMissingDomainScanWithOtherStringsInFile()
+    {
+        $translations = (new Translations())->setDomain('unknown-domain');
+
+        PhpCode::fromFileMultiple(static::asset('phpcode6/input.php'), [$translations]);
+
+        self::assertCount(0, $translations);
+    }
+
     public function testXliffUnitIds()
     {
         $translations = static::get('xliff/Xliff', 'Xliff', ['unitid_as_id' => true]);
@@ -580,6 +589,6 @@ class AssetsTest extends AbstractTest
 
         // Converting from an XLIFF that contains duplicate <source> elements
         // to a PO file will result in the loss of the duplicates.
-        $this->runTestFormat('xliff/Po', $countTranslations-1, $countTranslated-1, $countHeaders);
+        $this->runTestFormat('xliff/Po', $countTranslations - 1, $countTranslated - 1, $countHeaders);
     }
 }

--- a/tests/assets/phpcode6/input.php
+++ b/tests/assets/phpcode6/input.php
@@ -1,0 +1,6 @@
+<?php
+
+pgettext('context', 'Text with context');
+_('No domain text');
+
+dgettext('other', 'Other domain text');


### PR DESCRIPTION
Fixes this error: https://github.com/php-gettext/Gettext/issues/228

There was a wrong `if` condition. Created a test which fails. Patch fixes this simple case.