### PR TITLE
fixed diacritics for vuejs extractor from <template> element

### DIFF
--- a/src/Extractors/VueJs.php
+++ b/src/Extractors/VueJs.php
@@ -165,7 +165,7 @@ class VueJs extends Extractor implements ExtractorInterface, ExtractorMultiInter
         $dom = new DOMDocument;
 
         libxml_use_internal_errors(true);
-        $dom->loadHTML($html);
+        $dom->loadHTML(mb_convert_encoding($html, 'HTML-ENTITIES', 'UTF-8'));
 
         libxml_clear_errors();
 

--- a/tests/assets/vuejs2/domainNone.po
+++ b/tests/assets/vuejs2/domainNone.po
@@ -13,6 +13,10 @@ msgstr ""
 msgid "no domain 3"
 msgstr ""
 
+#: ./tests/assets/vuejs2/input.vue:11
+msgid "no domain 4 with diacritics čťľďáé"
+msgstr ""
+
 #: ./tests/assets/vuejs2/input.vue:2
 msgid "no domain 1"
 msgstr ""

--- a/tests/assets/vuejs2/input.vue
+++ b/tests/assets/vuejs2/input.vue
@@ -8,6 +8,7 @@
     {{dgettext('domain2', 'domain2 text')}}
 
     <label :v-text="__('no domain 3')"></label>
+    <label :v-text="__('no domain 4 with diacritics čťľďáé')"></label>
 
 </template>
 


### PR DESCRIPTION
Hello,

At the beginning, thanks for this awesome package. 

Version: v4.8.1
PHP: 7.2
Env: Mac OS - Cataline, Ubuntu server...

If you want import text with diacritics from vuejs `<template>` element with PHP extractor, output will be with buggy diacritics...

**VueJS**
```html
<template>
    {{ __('text with diacritics čťľďáé') }}
</template>
```

**PHP**
```php
Translations::fromVueJsFile(...)
```

Response will be **x04text with diacritics ÄÅ¥Ä¾ÄÃ¡Ã©** , but should be **text with diacritics čťľďáé**.

Fixed, and added tests... Hope everything is okay. Please could you publish new tag in v4?

Thanks.