### PR TITLE
Fix UTF-8 handling for VueJs scanner.

### DIFF
--- a/src/Extractors/VueJs.php
+++ b/src/Extractors/VueJs.php
@@ -165,7 +165,10 @@ class VueJs extends Extractor implements ExtractorInterface, ExtractorMultiInter
         $dom = new DOMDocument;
 
         libxml_use_internal_errors(true);
-        $dom->loadHTML($html);
+
+        // Prepend xml encoding so DOMDocument document handles UTF8 correctly.
+        // Assuming that vue template files will not have any xml encoding tags, because duplicate tags may be ignored.
+        $dom->loadHTML('<?xml encoding="utf-8"?>' . $html);
 
         libxml_clear_errors();
 

--- a/tests/AssetsTest.php
+++ b/tests/AssetsTest.php
@@ -548,6 +548,18 @@ class AssetsTest extends AbstractTest
         }
     }
 
+    public function testVueJsUtf8Scanning()
+    {
+        $translations = new Translations();
+
+        VueJs::fromFile(static::asset('vuejs3/input.vue'), $translations);
+
+        self::assertCount(2, $translations);
+
+        self::assertNotFalse($translations->find('', 'Let’s test ā ūtf8 štriņģ ❤️'));
+        self::assertNotFalse($translations->find('', 'We’re happy to have you here, 愛'));
+    }
+
     public function testXliffUnitIds()
     {
         $translations = static::get('xliff/Xliff', 'Xliff', ['unitid_as_id' => true]);

--- a/tests/AssetsTest.php
+++ b/tests/AssetsTest.php
@@ -565,7 +565,7 @@ class AssetsTest extends AbstractTest
 
         self::assertCount(2, $translations);
 
-        self::assertNotFalse($translations->find('', 'Let’s test ā ūtf8 štriņģ ❤️'));
+        self::assertNotFalse($translations->find('', 'Let’s test ā ūtf8 štriņģ 😎️'));
         self::assertNotFalse($translations->find('', 'We’re happy to have you here, 愛'));
     }
 

--- a/tests/assets/vuejs3/input.vue
+++ b/tests/assets/vuejs3/input.vue
@@ -1,5 +1,5 @@
 <template>
-    {{ __('Let’s test ā ūtf8 štriņģ ❤️') }}
+    {{ __('Let’s test ā ūtf8 štriņģ 😎️') }}
 </template>
 
 <script>

--- a/tests/assets/vuejs3/input.vue
+++ b/tests/assets/vuejs3/input.vue
@@ -1,0 +1,13 @@
+<template>
+    {{ __('Let’s test ā ūtf8 štriņģ ❤️') }}
+</template>
+
+<script>
+    export default {
+        computed: {
+            buttonText() {
+                return __('We’re happy to have you here, 愛');
+            }
+        },
+    }
+</script>


### PR DESCRIPTION
DOMDocument does not handle UTF8 well without using htmlentities() or prepending XM encoding tag.

Added a fix and a test.