### PR TITLE
Update Scanner.php

### DIFF
--- a/src/Scanner/Scanner.php
+++ b/src/Scanner/Scanner.php
@@ -77,6 +77,12 @@ abstract class Scanner implements ScannerInterface
      */
     protected static function readFile(string $file): string
     {
+        // handled generated notice on php 7.4 if its not file
+        // by insuring it should be file
+        if(!is_file($file)) {
+            return '';
+        }
+        
         $length = filesize($file);
 
         if (!($fd = fopen($file, 'rb'))) {


### PR DESCRIPTION
handled generated notice on php 7.4 if its not file by by insuring it should be file, which further generate fatal error as fread returns false.