### PR TITLE
Fixed integer bug in filename type from references

### DIFF
--- a/src/References.php
+++ b/src/References.php
@@ -68,13 +68,10 @@ class References implements JsonSerializable, Countable, IteratorAggregate
         $merged = clone $this;
 
         foreach ($references as $filename => $lines) {
-            if (empty($lines)) {
-                //Check the $filename type
-                if (gettype($filename) == "integer") {
-                    //Set string
-                    $filename = strval($filename);   
-                }
-
+            //Set filename always to string
+			$filename = (string) $filename;
+			
+			if (empty($lines)) {
                 $merged->add($filename);
                 continue;
             }

--- a/src/References.php
+++ b/src/References.php
@@ -70,9 +70,10 @@ class References implements JsonSerializable, Countable, IteratorAggregate
         foreach ($references as $filename => $lines) {
             if (empty($lines)) {
                 //Check the $filename type
-                if(gettype($filename) == "integer")
+                if (gettype($filename) == "integer") {
                     //Set string
-                    $filename = strval($filename);
+                    $filename = strval($filename);   
+                }
 
                 $merged->add($filename);
                 continue;

--- a/src/References.php
+++ b/src/References.php
@@ -69,6 +69,11 @@ class References implements JsonSerializable, Countable, IteratorAggregate
 
         foreach ($references as $filename => $lines) {
             if (empty($lines)) {
+                //Check the $filename type
+                if(gettype($filename) == "integer")
+                    //Set string
+                    $filename = strval($filename);
+
                 $merged->add($filename);
                 continue;
             }


### PR DESCRIPTION
Hello. I found a bug with GetText. When it updates a translation, if References is a numeric value, the program crashes.

A solution would be checking first if it is a numeric value, else it converts the number into a text string.

ERROR:
`PHP Fatal error:  Uncaught TypeError: Argument 1 passed to Gettext\References::add() must be of the type string, int given, called in C:\Users\iinfe\PhpstormProjects\TranslationWorks\vendor\gettext\gettext\src\References.php on line 72 and defined in C:\Users\iinfe\PhpstormProjects\TranslationWorks\vendor\gettext\gettext\src\References.php:31
`

ENTRY EXAMPLE:
```
#. Igor
#: 1
msgctxt "E101_001.PTP:1:3"
msgid ""
"It may be that such a fate awaits you\n"
"in the near future."
msgstr ""
"Puede que tal destino te aguarde en\n"
"un futuro próximo."
```