### PR TITLE
Blade Extractor improvement for Laravel 8/Jetstream (Gettext 4.x branch)

### DIFF
--- a/src/Extractors/Blade.php
+++ b/src/Extractors/Blade.php
@@ -19,6 +19,11 @@ class Blade extends Extractor implements ExtractorInterface
         if (empty($options['facade'])) {
             $cachePath = empty($options['cachePath']) ? sys_get_temp_dir() : $options['cachePath'];
             $bladeCompiler = new BladeCompiler(new Filesystem(), $cachePath);
+
+            if(method_exists($bladeCompiler, 'withoutComponentTags')) {
+                $bladeCompiler->withoutComponentTags();
+            }
+
             $string = $bladeCompiler->compileString($string);
         } else {
             $string = $options['facade']::compileString($string);

--- a/src/Extractors/Blade.php
+++ b/src/Extractors/Blade.php
@@ -20,7 +20,7 @@ class Blade extends Extractor implements ExtractorInterface
             $cachePath = empty($options['cachePath']) ? sys_get_temp_dir() : $options['cachePath'];
             $bladeCompiler = new BladeCompiler(new Filesystem(), $cachePath);
 
-            if(method_exists($bladeCompiler, 'withoutComponentTags')) {
+            if (method_exists($bladeCompiler, 'withoutComponentTags')) {
                 $bladeCompiler->withoutComponentTags();
             }
 


### PR DESCRIPTION
In a new Laravel 8 Jetstream project (created with `laravel new [name] --jet`), there is an exception when using `Extractors\Blade::fromFile($file, $translations);`

```
  Unable to locate a class or view for component [jet-input].

  at vendor/laravel/framework/src/Illuminate/View/Compilers/ComponentTagCompiler.php:273
    269▕         if ($viewFactory->exists($view = $this->guessViewName($component))) {
    270▕             return $view;
    271▕         }
    272▕ 
  ➜ 273▕         throw new InvalidArgumentException(
    274▕             "Unable to locate a class or view for component [{$component}]."
    275▕         );
    276▕     }
    277▕ 

      +2 vendor frames 
  3   [internal]:0
      Illuminate\View\Compilers\ComponentTagCompiler::Illuminate\View\Compilers\{closure}(["<x-jet-input type="password" class="mt-1 block w-3/4" placeholder="Password"
                                x-ref="password"
                                wire:model.defer="password"
                                wire:keydown.enter="logoutOtherBrowserSessions" />", "jet-input", " type="password" class="mt-1 block w-3/4" placeholder="Password"
                                x-ref="password"
                                wire:model.defer="password"
                                wire:keydown.enter="logoutOtherBrowserSessions" ", " type="password" class="mt-1 block w-3/4" placeholder="Password"
                                x-ref="password"
                                wire:model.defer="password"
                                wire:keydown.enter="logoutOtherBrowserSessions" ", "="logoutOtherBrowserSessions""])

```

It seems to be unable to locate the jet components, and therefore can't compile the Blade file to PHP.

i don't exactly know why it breaks, but a lot of things are recently updated regarding ComponentTag namespaces and it might be related to this error? (cf. https://github.com/laravel/framework/commit/7cc120ebfcccdecf02d5cdbec47f6eae63a8e5a9).

However, if I'm right, **the Blade extractor doesn't need to compile ComponentTag to do its job correctly**, so I created this pull request to always disable it, so that the 4.x branch could still work with Laravel 8/Jetstream.

i hope that makes sense!