### PR TITLE
Multiline disabled translations

### DIFF
--- a/src/Loader/PoLoader.php
+++ b/src/Loader/PoLoader.php
@@ -30,8 +30,7 @@ final class PoLoader extends Loader
             ) {
                 if (substr(trim($nextLine), 0, 1) === '"') { // Normal multiline
                     $line = substr($line, 0, -1).substr(trim($nextLine), 1);
-                }
-                if (substr(trim($nextLine), 0, 4) === '#~ "') { // Disabled multiline
+                } elseif (substr(trim($nextLine), 0, 4) === '#~ "') { // Disabled multiline
                     $line = substr($line, 0, -1).substr(trim($nextLine), 4);
                 }
                 $nextLine = next($lines);

--- a/src/Loader/PoLoader.php
+++ b/src/Loader/PoLoader.php
@@ -26,9 +26,14 @@ final class PoLoader extends Loader
             //Multiline
             while (substr($line, -1, 1) === '"'
                 && $nextLine !== false
-                && substr(trim($nextLine), 0, 1) === '"'
+                && (substr(trim($nextLine), 0, 1) === '"' || substr(trim($nextLine), 0, 4) === '#~ "')
             ) {
-                $line = substr($line, 0, -1).substr(trim($nextLine), 1);
+                if (substr(trim($nextLine), 0, 1) === '"') { // Normal multiline
+                    $line = substr($line, 0, -1).substr(trim($nextLine), 1);
+                }
+                if (substr(trim($nextLine), 0, 4) === '#~ "') { // Disabled multiline
+                    $line = substr($line, 0, -1).substr(trim($nextLine), 4);
+                }
                 $nextLine = next($lines);
             }
 


### PR DESCRIPTION
If .po file contain multiline disbled translations like this:

#~ msgid "Last agent hours-description"
#~ msgstr ""
#~ "How many hours in the past can system look at finding the last agent? "
#~ "This parameter is only used if 'Call Last Agent' is set to 'YES'."

only the first line was taken, this fix allow mutiline disabled translations.