### PR TITLE
PHP 8 compatibility (Gettext 4.x branch)

### DIFF
--- a/src/Utils/FunctionsScanner.php
+++ b/src/Utils/FunctionsScanner.php
@@ -30,7 +30,7 @@ abstract class FunctionsScanner
         $translations = is_array($translations) ? $translations : [$translations];
 
         /** @var Translations[] $translationByDomain [domain => translations, ..] */
-        $translationByDomain = array_reduce($translations, function (&$carry, Translations $translations) {
+        $translationByDomain = array_reduce($translations, function ($carry, Translations $translations) {
             $carry[$translations->getDomain()] = $translations;
             return $carry;
         }, []);


### PR DESCRIPTION
It just removes one char for PHP 8 compatibility (at least for [our specs](https://github.com/translation/laravel/tree/master/tests)).

The error fixed is `Argument #1 ($carry) must be passed by reference, value given`

-------

**Note**

We still use the Gettext 4.x branch as dependency in [translation/laravel](https://github.com/translation/laravel) (for [https://translation.io](https://translation.io/laravel)) to be able to keep using the Blade Extractor.

Do you know if someone already made a Blade Scanner compatible with 5.x?

Just for information, how hard do you think it would  be to create this scanner by using the code of your 4.x extractor?

Thanks for this great library!