### PR TITLE
PHP 8.1 compatibility

### DIFF
--- a/src/Comments.php
+++ b/src/Comments.php
@@ -7,6 +7,7 @@ use ArrayIterator;
 use Countable;
 use IteratorAggregate;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * Class to manage the comments of a translation.
@@ -56,11 +57,13 @@ class Comments implements JsonSerializable, Countable, IteratorAggregate
         return $this;
     }
 
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->toArray();
     }
 
+    #[ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator($this->comments);

--- a/src/Flags.php
+++ b/src/Flags.php
@@ -7,6 +7,7 @@ use ArrayIterator;
 use Countable;
 use IteratorAggregate;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * Class to manage the flags of a translation.
@@ -63,11 +64,13 @@ class Flags implements JsonSerializable, Countable, IteratorAggregate
         return in_array($flag, $this->flags, true);
     }
 
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->toArray();
     }
 
+    #[ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator($this->flags);

--- a/src/Headers.php
+++ b/src/Headers.php
@@ -8,6 +8,7 @@ use Countable;
 use InvalidArgumentException;
 use IteratorAggregate;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * Class to manage the headers of translations.
@@ -63,11 +64,13 @@ class Headers implements JsonSerializable, Countable, IteratorAggregate
         return $this;
     }
 
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->toArray();
     }
 
+    #[ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator($this->toArray());

--- a/src/References.php
+++ b/src/References.php
@@ -7,6 +7,7 @@ use ArrayIterator;
 use Countable;
 use IteratorAggregate;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * Class to manage the references of a translation.
@@ -41,11 +42,13 @@ class References implements JsonSerializable, Countable, IteratorAggregate
         return $this;
     }
 
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->toArray();
     }
 
+    #[ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator($this->references);

--- a/src/Translations.php
+++ b/src/Translations.php
@@ -8,6 +8,7 @@ use Countable;
 use Gettext\Languages\Language;
 use InvalidArgumentException;
 use IteratorAggregate;
+use ReturnTypeWillChange;
 
 /**
  * Class to manage a collection of translations under the same domain.
@@ -81,6 +82,7 @@ class Translations implements Countable, IteratorAggregate
         ];
     }
 
+    #[ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator($this->translations);


### PR DESCRIPTION
By setting `#[\ReturnTypeWillChange]` for `JsonSerializable` and `IteratorAggregate` interface implementations the warnings are fixed.
As `#` was previously only a sign for a comment, its backwards compatible to older PHP versions.

Closes #277 (PHP 8.1 compatibility: warnings about JsonSerializable compatibility)