### PR TITLE
Handle PHP 8 `T_NAME_FULLY_QUALIFIED` to fix issue #284

### DIFF
--- a/src/Utils/PhpFunctionsScanner.php
+++ b/src/Utils/PhpFunctionsScanner.php
@@ -90,6 +90,11 @@ class PhpFunctionsScanner extends FunctionsScanner
                 continue;
             }
 
+            if (defined('T_NAME_FULLY_QUALIFIED') && T_NAME_FULLY_QUALIFIED === $value[0]) {
+                $value[0] = T_STRING;
+                $value[1] = ltrim($value[1], '\\');
+            }
+
             switch ($value[0]) {
                 case T_CONSTANT_ENCAPSED_STRING:
                     //add an argument to the current function


### PR DESCRIPTION
Since PHP 8 function calls like `\__( 'Test', 'text-domain' )` are identified as `T_NAME_FULLY_QUALIFIED` instead of `T_STRING`. This will add PHP 8 support for fully qualified function calls like `\__( 'Test', 'text-domain' )`. See following issues for more details:

- https://github.com/php-gettext/Gettext/issues/284
- https://github.com/wp-cli/i18n-command/issues/344
