### PR TITLE
Fixed PHP 8.1 deprecation warning

### DIFF
--- a/src/Translations.php
+++ b/src/Translations.php
@@ -282,7 +282,7 @@ class Translations extends ArrayObject
     public function setHeader($name, $value)
     {
         $name = trim($name);
-        $this->headers[$name] = trim($value);
+        $this->headers[$name] = trim($value ?? '');
 
         return $this;
     }


### PR DESCRIPTION
Hi, and first thanks a lot for this library!

I've noticed another deprecation warning (ref #280) when upgrading to PHP 8.1 and fixed that here.

```
Deprecated: trim(): Passing null to parameter #1 ($string) of type string is deprecated
```