### PR TITLE
Fix PHP 8.4 explicit nullable compatibility

### DIFF
--- a/src/Loader/Loader.php
+++ b/src/Loader/Loader.php
@@ -12,14 +12,14 @@ use Gettext\Translations;
  */
 abstract class Loader implements LoaderInterface
 {
-    public function loadFile(string $filename, Translations $translations = null): Translations
+    public function loadFile(string $filename, ?Translations $translations = null): Translations
     {
         $string = static::readFile($filename);
 
         return $this->loadString($string, $translations);
     }
 
-    public function loadString(string $string, Translations $translations = null): Translations
+    public function loadString(string $string, ?Translations $translations = null): Translations
     {
         return $translations ?: $this->createTranslations();
     }
@@ -29,7 +29,7 @@ abstract class Loader implements LoaderInterface
         return Translations::create();
     }
 
-    protected function createTranslation(?string $context, string $original, string $plural = null): ?Translation
+    protected function createTranslation(?string $context, string $original, ?string $plural = null): ?Translation
     {
         $translation = Translation::create($context, $original);
 

--- a/src/Loader/LoaderInterface.php
+++ b/src/Loader/LoaderInterface.php
@@ -7,7 +7,7 @@ use Gettext\Translations;
 
 interface LoaderInterface
 {
-    public function loadFile(string $filename, Translations $translations = null): Translations;
+    public function loadFile(string $filename, ?Translations $translations = null): Translations;
 
-    public function loadString(string $string, Translations $translations = null): Translations;
+    public function loadString(string $string, ?Translations $translations = null): Translations;
 }

--- a/src/Loader/MoLoader.php
+++ b/src/Loader/MoLoader.php
@@ -19,7 +19,7 @@ final class MoLoader extends Loader
     private const MAGIC2 = -569244523;
     private const MAGIC3 = 2500072158;
 
-    public function loadString(string $string, Translations $translations = null): Translations
+    public function loadString(string $string, ?Translations $translations = null): Translations
     {
         $translations = parent::loadString($string, $translations);
         $this->init($string);

--- a/src/Loader/PoLoader.php
+++ b/src/Loader/PoLoader.php
@@ -11,7 +11,7 @@ use Gettext\Translations;
  */
 final class PoLoader extends Loader
 {
-    public function loadString(string $string, Translations $translations = null): Translations
+    public function loadString(string $string, ?Translations $translations = null): Translations
     {
         $translations = parent::loadString($string, $translations);
 

--- a/src/Loader/StrictPoLoader.php
+++ b/src/Loader/StrictPoLoader.php
@@ -41,7 +41,7 @@ final class StrictPoLoader extends Loader
     /**
      * Generates a Translations object from a .po based string
      */
-    public function loadString(string $data, Translations $translations = null): Translations
+    public function loadString(string $data, ?Translations $translations = null): Translations
     {
         $this->data = $data;
         $this->position = 0;

--- a/src/References.php
+++ b/src/References.php
@@ -29,7 +29,7 @@ class References implements JsonSerializable, Countable, IteratorAggregate
         return $this->toArray();
     }
 
-    public function add(string $filename, int $line = null): self
+    public function add(string $filename, ?int $line = null): self
     {
         $fileReferences = $this->references[$filename] ?? [];
 

--- a/src/Scanner/ParsedFunction.php
+++ b/src/Scanner/ParsedFunction.php
@@ -16,7 +16,7 @@ final class ParsedFunction
     private $comments = [];
     private $flags = [];
 
-    public function __construct(string $name, string $filename, int $line, int $lastLine = null)
+    public function __construct(string $name, string $filename, int $line, ?int $lastLine = null)
     {
         $this->name = $name;
         $this->filename = $filename;

--- a/src/Translation.php
+++ b/src/Translation.php
@@ -194,7 +194,7 @@ class Translation
         return $this;
     }
 
-    public function getPluralTranslations(int $size = null): array
+    public function getPluralTranslations(?int $size = null): array
     {
         if ($size === null) {
             return $this->pluralTranslations;

--- a/src/Translations.php
+++ b/src/Translations.php
@@ -20,7 +20,7 @@ class Translations implements Countable, IteratorAggregate
     protected $headers;
     protected $flags;
 
-    public static function create(string $domain = null, string $language = null): Translations
+    public static function create(?string $domain = null, ?string $language = null): Translations
     {
         $translations = new static();
 


### PR DESCRIPTION
The upcoming release of PHP 8.4 will deprecate the use of implicit nullable types (`string $str = null`) and requires the explicit nullable type instead (`?string $str = null`). This PR modifies all occurences of the implicit nullable type such that this project should be compatible with PHP 8.4 at least in that regard. The modifications do not change any logic, just adding syntactic sugar, which will be required starting with 8.4.