### PR TITLE
Add PHPStan level 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "brick/varexporter": "^0.3.5",
         "friendsofphp/php-cs-fixer": "^3.2",
         "oscarotero/php-cs-fixer-config": "^2.0",
-        "phpstan/phpstan": "^2.1"
+        "phpstan/phpstan": "^1|^2"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
         "squizlabs/php_codesniffer": "^3.0",
         "brick/varexporter": "^0.3.5",
         "friendsofphp/php-cs-fixer": "^3.2",
-        "oscarotero/php-cs-fixer-config": "^2.0"
+        "oscarotero/php-cs-fixer-config": "^2.0",
+        "phpstan/phpstan": "^2.1"
     },
     "autoload": {
         "psr-4": {
@@ -41,7 +42,8 @@
     "scripts": {
         "test": [
             "phpunit",
-            "phpcs"
+            "phpcs",
+            "phpstan"
         ],
         "cs-fix": "php-cs-fixer fix"
     }

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -1,0 +1,5 @@
+parameters:
+    level: 0
+    paths:
+    - src
+    - tests

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -1,5 +1,5 @@
 parameters:
-    level: 4
+    level: 5
     paths:
     - src
     - tests

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -1,5 +1,5 @@
 parameters:
-    level: 1
+    level: 4
     paths:
     - src
     - tests

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -1,5 +1,5 @@
 parameters:
-    level: 0
+    level: 1
     paths:
     - src
     - tests

--- a/src/Comments.php
+++ b/src/Comments.php
@@ -11,6 +11,8 @@ use ReturnTypeWillChange;
 
 /**
  * Class to manage the comments of a translation.
+ *
+ * @phpstan-consistent-constructor
  */
 class Comments implements JsonSerializable, Countable, IteratorAggregate
 {

--- a/src/Flags.php
+++ b/src/Flags.php
@@ -11,6 +11,8 @@ use ReturnTypeWillChange;
 
 /**
  * Class to manage the flags of a translation.
+ *
+ * @phpstan-consistent-constructor
  */
 class Flags implements JsonSerializable, Countable, IteratorAggregate
 {

--- a/src/Headers.php
+++ b/src/Headers.php
@@ -12,6 +12,8 @@ use ReturnTypeWillChange;
 
 /**
  * Class to manage the headers of translations.
+ *
+ * @phpstan-consistent-constructor
  */
 class Headers implements JsonSerializable, Countable, IteratorAggregate
 {

--- a/src/Loader/MoLoader.php
+++ b/src/Loader/MoLoader.php
@@ -125,9 +125,7 @@ final class MoLoader extends Loader
 
     private function readInt(string $byteOrder): int
     {
-        if (($read = $this->read(4)) === false) {
-            return 0;
-        }
+        $read = $this->read(4);
 
         $read = (array) unpack($byteOrder, $read);
 

--- a/src/Loader/PoLoader.php
+++ b/src/Loader/PoLoader.php
@@ -24,8 +24,8 @@ final class PoLoader extends Loader
             $nextLine = next($lines);
 
             // Treat empty comments as empty lines https://github.com/php-gettext/Gettext/pull/296
-            if ($line === "#") {
-                $line = "";
+            if ($line === '#') {
+                $line = '';
             }
 
             //Multiline

--- a/src/Loader/StrictPoLoader.php
+++ b/src/Loader/StrictPoLoader.php
@@ -35,8 +35,6 @@ final class StrictPoLoader extends Loader
     private $warnings = [];
     /** @var bool */
     private $isDisabled;
-    /** @var bool */
-    private $displayLineColumn;
 
     /**
      * Generates a Translations object from a .po based string

--- a/src/Loader/StrictPoLoader.php
+++ b/src/Loader/StrictPoLoader.php
@@ -323,8 +323,15 @@ final class StrictPoLoader extends Loader
      */
     private function readContext(): bool
     {
-        return ($data = $this->readIdentifier('msgctxt')) !== null
-            && ($this->translation = $this->translation->withContext($data));
+        $data = $this->readIdentifier('msgctxt');
+
+        if ($data === null) {
+            return false;
+        }
+
+        $this->translation = $this->translation->withContext($data);
+
+        return true;
     }
 
     /**

--- a/src/Loader/StrictPoLoader.php
+++ b/src/Loader/StrictPoLoader.php
@@ -167,7 +167,7 @@ final class StrictPoLoader extends Loader
     private function readQuotedString(?string $context = null): string
     {
         $this->readWhitespace();
-        for ($data = '', $isNewPart = true, $checkpoint = null; ;) {
+        for ($data = '', $isNewPart = true, $checkpoint = null;;) {
             if ($isNewPart && !$this->readChar('"')) {
                 // The data is over (e.g. beginning of an identifier) or perhaps there's an error
                 // Restore the checkpoint and let the next parser handle it

--- a/src/Loader/StrictPoLoader.php
+++ b/src/Loader/StrictPoLoader.php
@@ -347,7 +347,15 @@ final class StrictPoLoader extends Loader
      */
     private function readPlural(): bool
     {
-        return ($data = $this->readIdentifier('msgid_plural')) !== null && $this->translation->setPlural($data);
+        $data = $this->readIdentifier('msgid_plural');
+
+        if ($data === null) {
+            return false;
+        }
+
+        $this->translation->setPlural($data);
+
+        return true;
     }
 
     /**

--- a/src/Loader/StrictPoLoader.php
+++ b/src/Loader/StrictPoLoader.php
@@ -167,7 +167,7 @@ final class StrictPoLoader extends Loader
     private function readQuotedString(?string $context = null): string
     {
         $this->readWhitespace();
-        for ($data = '', $isNewPart = true, $checkpoint = null;;) {
+        for ($data = '', $isNewPart = true, $checkpoint = null; ;) {
             if ($isNewPart && !$this->readChar('"')) {
                 // The data is over (e.g. beginning of an identifier) or perhaps there's an error
                 // Restore the checkpoint and let the next parser handle it
@@ -192,11 +192,11 @@ final class StrictPoLoader extends Loader
                 case '\\':
                     $data .= $this->readEscape();
                     break;
-                // Unexpected newline
+                    // Unexpected newline
                 case "\r":
                 case "\n":
                     throw new Exception("Newline character must be escaped{$this->getErrorPosition()}");
-                // Unexpected end of file
+                    // Unexpected end of file
                 case null:
                     throw new Exception("Expected a closing quote{$this->getErrorPosition()}");
             }
@@ -227,6 +227,7 @@ final class StrictPoLoader extends Loader
                 return chr($decimal);
             case 'x':
                 $value = $this->readCharset($hexDigits, 1, PHP_INT_MAX, 'hexadecimal');
+
                 // GNU reads all valid hexadecimal chars, but only uses the last pair
                 return hex2bin(str_pad(substr($value, -2), 2, '0', STR_PAD_LEFT));
             case 'U':

--- a/src/Merge.php
+++ b/src/Merge.php
@@ -30,7 +30,7 @@ final class Merge
 
     //Merge strategies
     public const SCAN_AND_LOAD =
-          Merge::HEADERS_OVERRIDE
+        Merge::HEADERS_OVERRIDE
         | Merge::TRANSLATIONS_OURS
         | Merge::TRANSLATIONS_OVERRIDE
         | Merge::EXTRACTED_COMMENTS_OURS

--- a/src/References.php
+++ b/src/References.php
@@ -11,6 +11,8 @@ use ReturnTypeWillChange;
 
 /**
  * Class to manage the references of a translation.
+ *
+ * @phpstan-consistent-constructor
  */
 class References implements JsonSerializable, Countable, IteratorAggregate
 {
@@ -22,6 +24,10 @@ class References implements JsonSerializable, Countable, IteratorAggregate
         $references->references = $state['references'];
 
         return $references;
+    }
+
+    public function __construct()
+    {
     }
 
     public function __debugInfo()

--- a/src/Scanner/FunctionsHandlersTrait.php
+++ b/src/Scanner/FunctionsHandlersTrait.php
@@ -7,6 +7,8 @@ use Gettext\Translation;
 
 /**
  * Trait with common gettext function handlers
+ *
+ * @phpstan-ignore trait.unused
  */
 trait FunctionsHandlersTrait
 {

--- a/src/Scanner/ParsedFunction.php
+++ b/src/Scanner/ParsedFunction.php
@@ -24,7 +24,7 @@ final class ParsedFunction
         $this->lastLine = isset($lastLine) ? $lastLine : $line;
     }
 
-    public function __debugInfo()
+    public function __debugInfo(): array
     {
         return $this->toArray();
     }

--- a/src/Translation.php
+++ b/src/Translation.php
@@ -5,6 +5,8 @@ namespace Gettext;
 
 /**
  * Class to manage an individual translation.
+ *
+ * @phpstan-consistent-constructor
  */
 class Translation
 {

--- a/src/Translations.php
+++ b/src/Translations.php
@@ -12,6 +12,8 @@ use ReturnTypeWillChange;
 
 /**
  * Class to manage a collection of translations under the same domain.
+ *
+ * @phpstan-consistent-constructor
  */
 class Translations implements Countable, IteratorAggregate
 {

--- a/tests/BasePoLoaderTestCase.php
+++ b/tests/BasePoLoaderTestCase.php
@@ -24,7 +24,7 @@ Copyright (C) YEAR Free Software Foundation, Inc.
 This file is distributed under the same license as the PACKAGE package.
 FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 EOT
-        ,
+            ,
             $description
         );
 

--- a/tests/MoGeneratorTest.php
+++ b/tests/MoGeneratorTest.php
@@ -26,7 +26,7 @@ class MoGeneratorTest extends TestCase
         $translation->translate('Orixinal');
         $translations->add($translation);
 
-        $translation = Translation::create('context-1', 'Other comment', 'Other comments');
+        $translation = Translation::create('context-1', 'Other comment');
         $translation->translate('Outro comentario');
         $translation->translatePlural('Outros comentarios');
         $translations->add($translation);

--- a/tests/PoGeneratorTest.php
+++ b/tests/PoGeneratorTest.php
@@ -33,7 +33,7 @@ EOT
         $translation->getReferences()->add('/my/template.php', 45);
         $translations->add($translation);
 
-        $translation = Translation::create('context-1', 'Other comment', 'Other comments');
+        $translation = Translation::create('context-1', 'Other comment');
         $translation->translate('Outro comentario');
         $translation->translatePlural('Outros comentarios');
         $translation->getExtractedComments()->add('Not sure about this');


### PR DESCRIPTION
Hi @oscarotero, I propose to add PHPStan slowly to improve the type coverage.

It may trigger some architectural questions, for example we are getting this error at level 0:

```
 ------ ----------------------------------------------------------------------------------- 
  Line   src/Flags.php                                                                      
 ------ ----------------------------------------------------------------------------------- 
  21     Unsafe usage of new static().                                                      
         🪪  new.static                                                                      
         💡 See: https://phpstan.org/blog/solving-phpstan-error-unsafe-usage-of-new-static   
 ------ ----------------------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------------- 
  Line   src/Headers.php                                                                    
 ------ ----------------------------------------------------------------------------------- 
  26     Unsafe usage of new static().                                                      
         🪪  new.static                                                                      
         💡 See: https://phpstan.org/blog/solving-phpstan-error-unsafe-usage-of-new-static   
 ------ ----------------------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------------- 
  Line   src/References.php                                                                 
 ------ ----------------------------------------------------------------------------------- 
  21     Unsafe usage of new static().                                                      
         🪪  new.static                                                                      
         💡 See: https://phpstan.org/blog/solving-phpstan-error-unsafe-usage-of-new-static   
 ------ ----------------------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------------- 
  Line   src/Translation.php                                                                
 ------ ----------------------------------------------------------------------------------- 
  30     Unsafe usage of new static().                                                      
         🪪  new.static                                                                      
         💡 See: https://phpstan.org/blog/solving-phpstan-error-unsafe-usage-of-new-static   
 ------ ----------------------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------------- 
  Line   src/Translations.php                                                               
 ------ ----------------------------------------------------------------------------------- 
  25     Unsafe usage of new static().                                                      
         🪪  new.static                                                                      
         💡 See: https://phpstan.org/blog/solving-phpstan-error-unsafe-usage-of-new-static   
 ------ -----------------------------------------------------------------------------------
 ```
 
 It's not a big deal to fix, but making the class or the constructor final would be a breaking change, and I have no idea if it follows how you want to keep evolving this library.